### PR TITLE
Disable caching for index.html

### DIFF
--- a/roles/nginx/templates/nginx.conf.j2
+++ b/roles/nginx/templates/nginx.conf.j2
@@ -129,7 +129,7 @@ http {
       location / {
         root /var/www/freefeed-react-client/public;
         access_log off;
-        expires max;
+        expires off;
         try_files $uri $uri/ /index.html?/$request_uri;
       }
       location ~ ^/assets/ {


### PR DESCRIPTION
**WAIT, DO NOT MERGE**

It seems it would disable caching for these two as well:

```
    <link rel="stylesheet" href="/common-fc55d007b2068e151f75724b79a7274b.css">
    <link rel="stylesheet" href="/app-698fbdc923edcadddecb682442a92774.css">
```
