### PR TITLE
Adjust pepyatka-lite config to use /s/ path to static

### DIFF
--- a/roles/nginx/templates/pepyatka-lite-config.json.j2
+++ b/roles/nginx/templates/pepyatka-lite-config.json.j2
@@ -1,7 +1,7 @@
 var gConfig = {
   "serverURL":"{{ pepyatka_frontend_scheme }}://{{ pepyatka_lite_hostname }}/v1/"
 , "front":"{{ pepyatka_frontend_scheme }}://{{ pepyatka_lite_hostname }}/"
-, "static":"{{ pepyatka_frontend_scheme }}://{{ pepyatka_lite_hostname }}/static/"
+, "static":"{{ pepyatka_frontend_scheme }}://{{ pepyatka_lite_hostname }}/s/"
 , "rtURL":"{{ pepyatka_frontend_scheme }}://{{ pepyatka_lite_hostname }}/socket.io/"
 , "offset":"30"
 , "likesFold":4


### PR DESCRIPTION
I've forgot that the config is taken from ansible, sorry
