### PR TITLE
Add catch-all server block with redirect

### DIFF
--- a/roles/nginx/templates/nginx.conf.j2
+++ b/roles/nginx/templates/nginx.conf.j2
@@ -75,6 +75,13 @@ http {
 {% endif %}
 {% endif %}
 
+    # must be first ssl block
+    server {
+      server_name _;
+      include pepyatka-ssl.conf;
+      return 301 $scheme://{{ pepyatka_hostname }}$request_uri;
+    }
+
     server {
       server_name {{ pepyatka_media_hostname }};
       include pepyatka-ssl.conf;


### PR DESCRIPTION
Any server names, non described in config (www.… for example), will be redirected to `pepyatka_hostname`.
