### PR TITLE
🔧🌐 Switch to custom search-config for candy

### DIFF
--- a/group_vars/release.yml
+++ b/group_vars/release.yml
@@ -21,6 +21,7 @@ postgres_host: 172.18.0.1
 postgres_port: 5432
 postgres_user: prodfeed
 postgres_dbname: prodfeed
+postgres_textsearch_config: pg_catalog.russian
 
 new_relic_app_name: "FreeFeed Production"
 public_sentry_dsn: 'https://abdac1f2db2d45efaa9142062fe14bd8@sentry.io/75960'

--- a/group_vars/stable.yml
+++ b/group_vars/stable.yml
@@ -22,6 +22,7 @@ postgres_host: 172.18.0.1
 postgres_port: 5432
 postgres_user: stagefeed
 postgres_dbname: stagefeed
+postgres_textsearch_config: public.freefeed_fts
 
 new_relic_app_name: "FreeFeed stable"
 public_sentry_dsn: 'https://c0d1b60991264cc4b56a1398db012900@sentry.io/79081'

--- a/roles/server/templates/local.json.j2
+++ b/roles/server/templates/local.json.j2
@@ -58,7 +58,8 @@
       "database": "{{ postgres_dbname }}",
       "user": "{{ postgres_user }}",
       "password": "{{ postgres_pass }}"
-    }
+    },
+    "textSearchConfigName": "{{ postgres_textsearch_config }}"
   },
   "performance": {
     "searchQueriesTimeout": 45000


### PR DESCRIPTION
This one is needed to switch server-app on Candy to the new postgres' text search configuration.

Configuration was created manually, earlier (but it would be nice to have it in ansible too, eventually!