### PR TITLE
Update the externalAuthProviders config key

### DIFF
--- a/roles/server/templates/local.json.j2
+++ b/roles/server/templates/local.json.j2
@@ -67,16 +67,22 @@
   "performance": {
     "searchQueriesTimeout": 45000
   },
-  "externalAuthProviders": {
-    "google": {
-      "clientId": "{{ freefeed_external_auth_google_client_id }}",
-      "clientSecret": "{{ freefeed_external_auth_google_client_secret }}"
+  "externalAuthProviders": [
+    {
+      "template": "google",
+      "params": {
+        "clientId": "{{ freefeed_external_auth_google_client_id }}",
+        "clientSecret": "{{ freefeed_external_auth_google_client_secret }}"
+      }
     },
-    "facebook": {
-      "clientId": "{{ freefeed_external_auth_facebook_client_id }}",
-      "clientSecret": "{{ freefeed_external_auth_facebook_client_secret }}"
+    {
+      "template": "facebook",
+      "params": {
+        "clientId": "{{ freefeed_external_auth_facebook_client_id }}",
+        "clientSecret": "{{ freefeed_external_auth_facebook_client_secret }}"
+      }
     }
-  },
+  ],
   "app_name": "{{ new_relic_app_name }}",
   "license_key": "{{ new_relic_license_key }}"
 }


### PR DESCRIPTION
The freefeed-server expects the new format in this key.

This server version is already on Candy but not on prod yet.