### PR TITLE
Make version.txt's URL relative

### DIFF
--- a/roles/react_client/templates/config.json.j2
+++ b/roles/react_client/templates/config.json.j2
@@ -27,7 +27,7 @@
     },
 
     "appVersionCheck": {
-      "url": "https://{{ freefeed_site_origin }}/version.txt",
+      "url": "/version.txt",
       "header": "Last-Modified",
       "intervalSec": 300
     }


### PR DESCRIPTION
Absolute URL requires a fine-tuning of CORS. We can safely use just '/version.txt' here.