### PR TITLE
Add config for rate limiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Deploying FreeFeed
 
 Requirements:
-* ansible
-* debian
-* docker
+
+- ansible
+- debian
+- docker
 
 stable/candy:
 
@@ -65,11 +66,11 @@ For more information: `ansible-vault --help`.
 
 ## Local test
 
-If you want to test changes in config templates locally, run this command:
+If you want to test changes in config templates locally,
 
-```
-ansible-playbook -i local playbooks/server.yml --diff --check --tags local-json --connection local -e freefeed_config_dir=/tmp/ -K
-```
-
-It will ask for sudo password, but it will not be used.
-However, without `--check` flag it will actually create files in `/tmp` directory.
+1. install ansible
+1. `cp freefeed local`, replace `freefeed.net` with `localhost` and `release_secrets` with `local_secrets`
+1. `cp host_vars/freefeed.net host_vars/localhost`
+1. create a vault password file with a password (e.g. `echo 123 >> local.vault`), edit `vault_password_file` in `ansible.cfg` to point to it
+1. create a `group_vars/local_secrets` file with fake secrets (see contents above), encrypt it with `ansible-vault encrypt`
+1. `ansible-playbook -i local playbooks/server.yml --diff --tags local-json --connection local -e freefeed_config_dir=$OUTPUT_DIR -K` (you might need to run it with sudo first)

--- a/host_vars/candy.freefeed.net
+++ b/host_vars/candy.freefeed.net
@@ -1,5 +1,4 @@
 ---
-
 freefeed_hostname: candy.freefeed.net
 freefeed_site: "{{ freefeed_hostname | replace('.', '_') }}"
 react_client_version: stable
@@ -8,10 +7,13 @@ freefeed_site_title: 'FreeFeed 🍭'
 
 freefeed_inv_required_for_signup: true
 freefeed_inv_create_conditions:
-  - [ "minAccountAge", { age: "P15D" } ]
-  - [ "maxInvitesCreated", { count: 3, interval: "P1D" } ]
-  - [ "maxInvitesCreated", { count: 60, interval: "P30D" } ]
-  - [ "minPostsCreated", { count: 5 } ]
-  - [ "minCommentsFromOthers", { count: 5 } ]
+  - ['minAccountAge', { age: 'P15D' }]
+  - ['maxInvitesCreated', { count: 3, interval: 'P1D' }]
+  - ['maxInvitesCreated', { count: 60, interval: 'P30D' }]
+  - ['minPostsCreated', { count: 5 }]
+  - ['minCommentsFromOthers', { count: 5 }]
 
 freefeed_ratelimit_enabled: true
+freefeed_ratelimit_anonymous_config: { duration: 'PT1M', maxRequests: { all: 20, GET: 100 } }
+freefeed_ratelimit_authenticated_config: { duration: 'PT1M', maxRequests: { all: 40, GET: 300, POST: 60 } }
+freefeed_ratelimit_repeat_block_multiplier: 1.5

--- a/host_vars/freefeed.net
+++ b/host_vars/freefeed.net
@@ -1,5 +1,4 @@
 ---
-
 freefeed_site_title: FreeFeed
 freefeed_hostname: freefeed.net
 freefeed_site: "{{ freefeed_hostname | replace('.', '_') }}"
@@ -11,8 +10,13 @@ freefeed_daily_registrations_limit: 15
 
 freefeed_inv_required_for_signup: true
 freefeed_inv_create_conditions:
-  - [ "minAccountAge", { age: "P15D" } ]
-  - [ "maxInvitesCreated", { count: 3, interval: "P1D" } ]
-  - [ "maxInvitesCreated", { count: 60, interval: "P30D" } ]
-  - [ "minPostsCreated", { count: 5 } ]
-  - [ "minCommentsFromOthers", { count: 5 } ]
+  - ['minAccountAge', { age: 'P15D' }]
+  - ['maxInvitesCreated', { count: 3, interval: 'P1D' }]
+  - ['maxInvitesCreated', { count: 60, interval: 'P30D' }]
+  - ['minPostsCreated', { count: 5 }]
+  - ['minCommentsFromOthers', { count: 5 }]
+
+freefeed_ratelimit_enabled: true
+freefeed_ratelimit_anonymous_config: { duration: 'PT1M', maxRequests: { all: 20, GET: 150 } }
+freefeed_ratelimit_authenticated_config: { duration: 'PT1M', maxRequests: { all: 40, GET: 300, POST: 60 } }
+freefeed_ratelimit_repeat_block_multiplier: 2

--- a/roles/server/templates/local.json.j2
+++ b/roles/server/templates/local.json.j2
@@ -107,6 +107,13 @@
     "canCreateIf": {{ freefeed_inv_create_conditions | default([]) | tojson }}
   },
   "rateLimit": {
-    "enabled": {{ freefeed_ratelimit_enabled | default(false) | tojson }}
+    "enabled": {{ freefeed_ratelimit_enabled | default(false) | tojson }},
+    "allowlist": {{ freefeed_ratelimit_allowlist | default(['::ffff:127.0.0.1']) | tojson }},
+    "anonymous": {{ freefeed_ratelimit_anonymous_config | default({"duration":"PT1M","maxRequests":{"all":10,"GET":100}}) | tojson }},
+    "authenticated": {{ freefeed_ratelimit_authenticated_config | default({"duration":"PT1M","maxRequests":{"all":30,"GET":200,"POST":60}}) | tojson }},
+    "maskingKeyRotationInterval": {{ freefeed_ratelimit_masking_key_rotation_interval | default("P7D") | tojson }},
+    "blockDuration": {{ freefeed_ratelimit_block_duration | default("PT1M") | tojson }},
+    "repeatBlockCounterDuration": {{ freefeed_ratelimit_repeat_block_counter_duration | default("PT10M") | tojson }},
+    "repeatBlockMultiplier": {{ freefeed_ratelimit_repeat_block_multiplier | default(2) }}
   }
 }


### PR DESCRIPTION
1. Improve documentation about generating configs locally
2. Add rate limiter config fields to config template
3. Enable rate limiter on candy
4. Enable rate limiter on prod 